### PR TITLE
Issue 36 - Prevenir execução

### DIFF
--- a/GestaoPessoasTests/Tests/WorkerServicePostGresTests.cs
+++ b/GestaoPessoasTests/Tests/WorkerServicePostGresTests.cs
@@ -26,6 +26,7 @@ namespace GestaoPessoasTests.Tests
 
             var configuration = applicationDomain.ServiceProvider.GetRequiredService<IConfiguration>();
             string? _connectionString = configuration.GetConnectionString("DefaultConnection");
+            if (_connectionString == null) Assert.Inconclusive("Não foi possível obter a connection string de configuração.");
             string? BackupPath = configuration.GetValue<string>("PostGresWorkerService:FilePath");
             if (BackupPath == null) throw new Exception("Não foi possível obter o caminho do ficheiro de configuração.");
 


### PR DESCRIPTION
Caso a connection string não seja encontrada ou não esteja configurada os testes postgres irão terminar com _inconclusive_.

Closes #36 